### PR TITLE
Automatic colour scheme

### DIFF
--- a/index.css
+++ b/index.css
@@ -1,14 +1,27 @@
 :root {
-  --background-muted: #333;
-  --background: #000;
+  --background-muted: #ccc;
+  --background: #fff;
 
-  --foreground-muted: #ccc;
-  --foreground: #fff;
+  --foreground-muted: #333;
+  --foreground: #000;
 
   --highlight-muted: #099;
-  --highlight: #0ff;
+  --highlight: #f00;
 
   --border: #888;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background-muted: #333;
+    --background: #000;
+
+    --foreground-muted: #ccc;
+    --foreground: #fff;
+
+    --highlight-muted: #099;
+    --highlight: #0ff;
+  }
 }
 
 body {

--- a/index.css
+++ b/index.css
@@ -1,7 +1,20 @@
+:root {
+  --background-muted: #333;
+  --background: #000;
+
+  --foreground-muted: #ccc;
+  --foreground: #fff;
+
+  --highlight-muted: #099;
+  --highlight: #0ff;
+
+  --border: #888;
+}
+
 body {
   align-items: stretch;
-  background: #333;
-  color: #ccc;
+  background: var(--background-muted);
+  color: var(--foreground-muted);
   display: grid;
   font-family: sans-serif;
   grid-template-areas:
@@ -74,7 +87,7 @@ main {
 }
 
 main #article {
-  background-color: #000;
+  background-color: var(--background);
   font-family: monospace;
   font-size: 18px;
   grid-area: article;
@@ -91,14 +104,14 @@ main #article h5 { font-size: 1.17em; } /* 0.83em */
 main #article h6 { font-size: 1.00em; } /* 0.67em */
 
 main #article span.highlight {
-  background-color: #099;
+  background-color: var(--highlight-muted);
   padding: 0 0.25em;
   margin: 0 -0.25em;
 }
 
 main #article span.highlight[data-scroll="true"] {
-  background-color: #0ff;
-  color: #000;
+  background-color: var(--highlight);
+  color: var(--background);
 }
 
 /* Content - Legibility mode */
@@ -111,7 +124,7 @@ main #article table {
 }
 
 main #article th {
-  background-color: #333;
+  background-color: var(--background-muted);
 }
 
 main #article th, main #article td {
@@ -133,7 +146,7 @@ main aside #guesses {
 
 main aside #guesses table {
   border-collapse: collapse;
-  color: #fff;
+  color: var(--foreground);
   width: 100%;
 }
 
@@ -147,8 +160,8 @@ main aside #guesses table tbody tr {
 }
 
 main aside #guesses table tbody tr.highlight {
-  background-color: #fff;
-  color: #000;
+  background-color: var(--foreground);
+  color: var(--background);
 }
 
 main aside #guesses table th:nth-child(2) {
@@ -193,7 +206,6 @@ dialog#stats table {
   width: 100%;
 }
 dialog#stats table th {
-  background-color: #fff;
   border-bottom: 3px solid currentColor;
   position: sticky;
   top: 0;
@@ -239,8 +251,8 @@ table td {
 }
 
 main button, main input[type="button"], main input[type="submit"] {
-  background-color: #333;
-  border: 1px solid #888;
+  background-color: var(--background-muted);
+  color: var(--foreground);
+  border: 1px solid var(--border);
   border-radius: 3px;
-  color: white;
 }


### PR DESCRIPTION
Hey @larsgw, thanks again for writing censordle!

Finally found time to add this since it was bothering me. I (especially) play on mobile, and often outdoors or on the train, and the dark theme is a bit of a contrast struggle for me in heavy daylight.

This PR is split into two commits: one replacing the colours used with CSS variables (so you can be sure they're all the same colours), the second commit adding a 'light' theme, and then using the [automatic toggle for dark theme](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme) based on the user's system/browser preferences, which is [quite well supported](https://caniuse.com/mdn-css_at-rules_media_prefers-color-scheme).

<details><summary>Image with very minor spoilers for 2023-07-01 (e.g. a country name's prevalence)</summary>

Please ignore the yellow, that is from my OS.
![censordle](https://github.com/larsgw/censordle/assets/458683/8fcc1c84-da95-49cf-9812-9c23761aa4c1)

</details>